### PR TITLE
Read feature files recursively from any directory (implementation)

### DIFF
--- a/src/runner.jl
+++ b/src/runner.jl
@@ -10,13 +10,18 @@ using Glob
 
 struct OSAL <: ExecutableSpecifications.OSAbstraction end
 function findfileswithextension(::OSAL, path::String, extension::String)
-    [joinpath(path, filename) for filename in readdir(path)
-              if isfile(joinpath(path, filename)) &&
-                 splitext(joinpath(path, filename))[2] == extension]
+    return rglob("*.$extension", path)
 end
 
 readfile(::OSAL, path::String) = read(path, String)
 fileexists(::OSAL, path::String) = isfile(path)
+
+"""
+    rglob(pattern, path)
+
+Find files recursively. 
+"""
+rglob(pattern, path) = Base.Iterators.flatten(map(d -> glob(pattern, d[1]), walkdir(path)))
 
 function parseonly(featurepath::String; parseoptions::ParseOptions=ParseOptions())
 
@@ -27,8 +32,6 @@ function parseonly(featurepath::String; parseoptions::ParseOptions=ParseOptions(
     driver = Driver(os, engine)
     # -----------------------------------------------------------------------------
 
-    # Find all feature files recursively
-    rglob(pat, topdir) = Base.Iterators.flatten(map(d -> glob(pat, d[1]), walkdir(topdir)))
     featurefiles = rglob("*.feature", featurepath)
 
     # Parse all feature files and collect results to an array of named tuples

--- a/src/runner.jl
+++ b/src/runner.jl
@@ -46,14 +46,25 @@ function parseonly(featurepath::String; parseoptions::ParseOptions=ParseOptions(
 end
 
 """
-    runspec()
+    runspec(rootpath; featurepath, stepspath, execenvpath, parseoptions)
 
-Execute all features found from the current directory, or another specified directory.
+Execute all features found from the `rootpath`.
+
+By default, it looks for feature files in `<rootpath>/features` and step files
+`<rootpath>/features/steps`. An `environment.jl` file may be added to 
+`<rootpath>/features` directory for running certain before/after code.
+You may override the default locations by specifying `featurepath`, 
+`stepspath`, or `execenvpath`.
+
+See also: [Gherkin.ParseOptions](@ref).
 """
-function runspec(rootpath::String = "."; parseoptions::ParseOptions=ParseOptions())
-    featurepath = joinpath(rootpath, "features")
-    stepspath = joinpath(featurepath, "steps")
-    execenvpath = joinpath(featurepath, "environment.jl")
+function runspec(
+    rootpath::String = ".";
+    featurepath = joinpath(rootpath, "features"),
+    stepspath = joinpath(featurepath, "steps"),
+    execenvpath = joinpath(featurepath, "environment.jl"),
+    parseoptions::ParseOptions=ParseOptions()
+)
     os = OSAL()
 
     executionenv = if fileexists(os, execenvpath)


### PR DESCRIPTION
Resolves #50.

Notes:
- The `findfileswithextension` function has been enhanced to find all matching files recursively in subdirectories. 
- I'm unsure why `OSAbstraction` is needed since Julia is already designed to be OS-agnostic; perhaps we can simplify it later.