### PR TITLE
add import ParseOptions & argument in example

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -29,9 +29,11 @@ step implementation, like the `Given` step does. To get a suggestion for missing
 implementations in a given feature file, you can run
 
 ```julia-repl
-julia> using ExecutableSpecifications
+julia> using ExecutableSpecifications: suggestmissingsteps, ParseOptions
 
-julia> suggestmissingsteps("features/SomeFeature.feature", "features/steps")
+julia> parseoptions = ParseOptions(allow_any_step_order=true)
+
+julia> suggestmissingsteps("features/SomeFeature.feature", "features/steps", parseoptions=parseoptions)
 using ExecutableSpecifications
 
 @when("a step is missing") do context


### PR DESCRIPTION
Looks like the ParseOptions needs to be imported as well here.
I also added the argument in the example, maybe obvious but helped me to start.